### PR TITLE
Addition of extended decimal list (styling) option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Addition of extended decimal list (styling) option (currently only for usage within Kaleidos)
+
 ## [3.10.1] - 2023-08-17
 
 ### Fixed

--- a/addon/components/plugins/list/ordered.ts
+++ b/addon/components/plugins/list/ordered.ts
@@ -27,6 +27,12 @@ export default class ListOrdered extends Component<Args> {
         ),
       },
       {
+        name: 'decimal-extended',
+        description: this.intl.t(
+          'ember-rdfa-editor.ordered-list.styles.decimal-extended'
+        ),
+      },
+      {
         name: 'lower-alpha',
         description: this.intl.t(
           'ember-rdfa-editor.ordered-list.styles.lower-alpha'

--- a/addon/config/sample-data.ts
+++ b/addon/config/sample-data.ts
@@ -373,6 +373,69 @@ export default {
               </ul>
             </li>
           </ul>
+          <h4>case 26 : numbered (extended) list</h4>
+          <ol data-list-style='decimal-extended'>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3
+              <ol>
+                <li>List item 3.1</li>
+                <li>List item 3.2</li>
+                <li>List item 3.3
+                  <ol>
+                    <li>List item 3.3.1</li>
+                      <ol data-list-style='lower-alpha'>
+                        <li>List item a</li>
+                        <li>List item b</li>
+                        <li>List item c</li>
+                      </ol>
+                    <li>List item 3.3.2</li>
+                    <li>List item 3.3.3</li>
+                  </ol>
+                </li>
+                <li>List item 3.4</li>
+              </ol>
+            </li>
+            <li>List item 4</li>
+            <li>List item 5</li>
+            <li>List item 6</li>
+            <li>List item 7
+              <ul>
+                <li>List item</li>
+                <li>List item</li>
+                <li>List item
+                  <ul>
+                    <li>List item</li>
+                    <li>List item
+                      <ol data-list-style='decimal'>
+                        <li>List item 1</li>
+                        <li>List item 2</li>
+                        <li>List item 3</li>
+                      </ol>
+                    </li>
+                    <li>List item
+                      <ol data-list-style='decimal-extended'>
+                        <li>List item 1</li>
+                        <li>List item 2</li>
+                        <li>List item 3
+                          <ol>
+                            <li>List item 3.1</li>
+                            <li>List item 3.2</li>
+                            <li>List item 3.3</li>
+                          </ol>
+                        </li>
+                      </ol>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+            <li>List item 8</li>
+            <li>List item 9</li>
+            <li>List item 10</li>
+            <li>List item 11</li>
+            <li>List item 12</li>
+          </ol>
       </div>`,
   brs: `<h1>Break heaven/hell</h1><br><br><p>Yo-ho-ho scourge of the seven seas log Shiver me timbers chase code of conduct fire in the hole gunwalls interloper dead men tell no tales. Bounty long clothes trysail Pirate Round Sink me parley fire in the hole reef sails red ensign coxswain. Bilge water dance the hempen jig draft mutiny fire in the hole Corsair crack Jennys tea cup run a rig driver swing the lead.<br></p><br><p>Yardarm transom draught Spanish Main rutters lass long clothes belay reef sails haul wind. Strike colors chase topgallant swing the lead topsail hail-shot cable Shiver me timbers hogshead warp. Draft rigging parrel nipperkin case shot crow's nest sutler pillage grapple trysail.<br></p><div>Shrouds spyglass yard black jack Gold Road sutler hornswaggle sloop splice the main brace knave. Furl ahoy quarterdeck hornswaggle walk the plank hang the jib scuttle hearties pirate American Main. Starboard pressgang Chain Shot wherry hail-shot lanyard killick topgallant galleon crim<br></div><br>Yo-ho-ho scourge of the seven seas log Shiver me timbers chase code of conduct fire in the hole gunwalls interloper dead men tell no tales. Bounty long clothes trysail Pirate Round Sink me parley fire in the hole reef sails red ensign coxswain. Bilge water dance the hempen jig draft mutiny fire in the hole Corsair crack Jennys tea cup run a rig driver swing the lead. <br><br>
 <h1>Breaks before blocks</h1>

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -244,6 +244,84 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
       list-style-type: lower-alpha;
     }
 
+    &[data-list-style='decimal-extended'] {
+      &,
+      ol:not(
+        [data-list-style='decimal'],
+        [data-list-style='upper-roman'],
+        [data-list-style='lower-alpha']
+      ) {
+        &,
+        &[data-list-style='decimal-extended'] { // This is needed for nested lists
+          display: table;
+          list-style-type: none;
+          counter-reset: item;
+          margin: 0;
+          padding: 0 0 0 .75rem;
+
+          > li {
+            display: table-row;
+            counter-increment: item;
+
+            &:before {
+              display: table-cell;
+              min-width: 2.75ch;
+              content: counters(item, ".") ". ";
+              text-align: end;
+            }
+          }
+        }
+      }
+
+      ol:not(
+        [data-list-style='decimal'],
+        [data-list-style='upper-roman'],
+        [data-list-style='lower-alpha']
+      ) {
+        > li {
+          &:before {
+            min-width: auto;
+          }
+        }
+      }
+
+      ol {
+        &,
+        &[data-list-style='decimal'],
+        &[data-list-style='upper-roman'],
+        &[data-list-style='lower-alpha'] {
+          li {
+            display: list-item;
+            counter-increment: none;
+
+            &:before{
+              display: inline;
+              content: none;
+            }
+
+            ol:not([data-list-style]) {
+              display: block;
+              counter-reset: none;
+              padding: 0 0 0 3rem;
+              list-style-type: inherit;
+            }
+          }
+        }
+
+        &[data-list-style='decimal'] {
+          list-style-type: decimal;
+        }
+
+        &[data-list-style='upper-roman'] {
+          list-style-type: upper-roman;
+        }
+
+        &[data-list-style='lower-alpha'] {
+          list-style-type: lower-alpha;
+        }
+      }
+    }
+
     // Stop indenting
     ol ol ol ol ol ol ol ol ol ol ol ol ol ol ol ol ol {
       margin-left: 0;

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -224,8 +224,7 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
     }
   }
 
-  ol,
-  ol.numbered-list {
+  ol {
     list-style-type: decimal;
 
     & > li > ol:not([data-list-style]) {
@@ -244,82 +243,71 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
       list-style-type: lower-alpha;
     }
 
+    // Provides the general styling for the decimal-extended (multi-level) list type
+    // NOTE: This is limited to a certain levels deep because otherwise the styling keep overriding each other (`[data-list-style='decimal-extended']` and the rest of the ol/ul selectors)
+    @mixin decimal-extended-styling($levels, $current-level: 1) {
+      display: table;
+      list-style-type: none;
+      margin: 0;
+      padding: 0 0 0 .75rem;
+
+      > li {
+        display: table-row;
+
+        &:before {
+          display: table-cell;
+          min-width: 2.75ch;
+          text-align: end;
+        }
+
+        @if $current-level < $levels {
+          > ol:not([data-list-style]) {
+            @include decimal-extended-styling($levels, $current-level + 1);
+          }
+        }
+      }
+    }
+
     &[data-list-style='decimal-extended'] {
+      @include decimal-extended-styling(5, 1);
+    }
+
+    // Provides the counter values for the decimal-extended (multi-level) list type for each time it is nested
+    @mixin decimal-extended-numbering($total, $times-nested) {
       &,
-      ol:not(
-        [data-list-style='decimal'],
-        [data-list-style='upper-roman'],
-        [data-list-style='lower-alpha']
-      ) {
-        &,
-        &[data-list-style='decimal-extended'] { // This is needed for nested lists
-          display: table;
-          list-style-type: none;
-          counter-reset: item;
-          margin: 0;
-          padding: 0 0 0 .75rem;
-
-          > li {
-            display: table-row;
-            counter-increment: item;
-
-            &:before {
-              display: table-cell;
-              min-width: 2.75ch;
-              content: counters(item, ".") ". ";
-              text-align: end;
-            }
-          }
-        }
-      }
-
-      ol:not(
-        [data-list-style='decimal'],
-        [data-list-style='upper-roman'],
-        [data-list-style='lower-alpha']
-      ) {
-        > li {
-          &:before {
-            min-width: auto;
-          }
-        }
-      }
-
       ol {
-        &,
-        &[data-list-style='decimal'],
-        &[data-list-style='upper-roman'],
-        &[data-list-style='lower-alpha'] {
-          li {
-            display: list-item;
-            counter-increment: none;
+        counter-reset: nested-#{$times-nested};
 
-            &:before{
-              display: inline;
-              content: none;
-            }
+        li {
+          counter-increment: nested-#{$times-nested};
 
-            ol:not([data-list-style]) {
-              display: block;
-              counter-reset: none;
-              padding: 0 0 0 3rem;
-              list-style-type: inherit;
-            }
+          &:before {
+            content: counters(nested-#{$times-nested}, ".") ". ";
           }
         }
+      }
 
-        &[data-list-style='decimal'] {
-          list-style-type: decimal;
-        }
-
-        &[data-list-style='upper-roman'] {
-          list-style-type: upper-roman;
-        }
-
-        &[data-list-style='lower-alpha'] {
-          list-style-type: lower-alpha;
+      // NOTE: This needs to be reset each time it is nested (because it is the only visible value)
+      ul,
+      ol[data-list-style='decimal'],
+      ol[data-list-style='upper-roman'],
+      ol[data-list-style='lower-alpha'] {
+        li {
+          &:before {
+            content: none;
+          }
         }
       }
+
+      @if $times-nested < $total {
+        ol[data-list-style='decimal-extended'] {
+          @include decimal-extended-numbering($total, $times-nested + 1);
+       }
+     }
+    }
+
+    &[data-list-style='decimal-extended'] {
+      @include decimal-extended-numbering(5, 1);
     }
 
     // Stop indenting

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -250,14 +250,17 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
       list-style-type: none;
       margin: 0;
       padding: 0 0 0 .75rem;
+      counter-reset: item;
 
       > li {
         display: table-row;
+        counter-increment: item;
 
         &:before {
           display: table-cell;
           min-width: 2.75ch;
           text-align: end;
+          content: counters(item, ".") ". ";
         }
 
         @if $current-level < $levels {
@@ -265,49 +268,60 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
             @include decimal-extended-styling($levels, $current-level + 1);
           }
         }
+
+        @if $current-level == $levels {
+          > ol:not([data-list-style]) {
+            list-style-type: decimal;
+
+            ol:not([data-list-style]) {
+              list-style-type: inherit;
+            }
+          }
+        }
       }
     }
 
     &[data-list-style='decimal-extended'] {
       @include decimal-extended-styling(5, 1);
-    }
 
-    // Provides the counter values for the decimal-extended (multi-level) list type for each time it is nested
-    @mixin decimal-extended-numbering($total, $times-nested) {
-      &,
-      ol {
-        counter-reset: nested-#{$times-nested};
+      ol[data-list-style='decimal-extended'] {
+        &,
+        ol {
+          display: block !important;
+          padding: 0 0 0 3rem !important;
+          counter-reset: none !important;
 
-        li {
-          counter-increment: nested-#{$times-nested};
+          li {
+            display: list-item !important;
+            counter-increment: none !important;
 
-          &:before {
-            content: counters(nested-#{$times-nested}, ".") ". ";
+            &:before{
+              display: inline !important;
+              content: none !important;
+            }
           }
         }
-      }
 
-      // NOTE: This needs to be reset each time it is nested (because it is the only visible value)
-      ul,
-      ol[data-list-style='decimal'],
-      ol[data-list-style='upper-roman'],
-      ol[data-list-style='lower-alpha'] {
-        li {
-          &:before {
-            content: none;
-          }
+        &[data-list-style='decimal-extended'] {
+          list-style-type: decimal !important;
+        }
+
+        & > li > ol:not([data-list-style]) {
+          list-style-type: inherit !important;
+        }
+
+        &[data-list-style='decimal'] {
+          list-style-type: decimal !important;
+        }
+
+        &[data-list-style='upper-roman'] {
+          list-style-type: upper-roman !important;
+        }
+
+        &[data-list-style='lower-alpha'] {
+          list-style-type: lower-alpha !important;
         }
       }
-
-      @if $times-nested < $total {
-        ol[data-list-style='decimal-extended'] {
-          @include decimal-extended-numbering($total, $times-nested + 1);
-       }
-     }
-    }
-
-    &[data-list-style='decimal-extended'] {
-      @include decimal-extended-numbering(5, 1);
     }
 
     // Stop indenting

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -15,6 +15,7 @@ ember-rdfa-editor:
     options-label: List styles
     styles:
       decimal: Numbers
+      decimal-extended: Numbers (extended)
       lower-alpha: Lowercase letters
       upper-roman: Roman Numbers
   unindent-list: List level higher

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -15,6 +15,7 @@ ember-rdfa-editor:
     options-label: Lijststijlen
     styles:
       decimal: Getallen
+      decimal-extended: Getallen (uitgebreid)
       lower-alpha: Letters
       upper-roman: Romeinse Cijfers
   unindent-list: Lijstniveau hoger


### PR DESCRIPTION
### Overview
The addition of an extended decimal list (styling) option to the 'ordered list' dropdown. The issue/request was described by Johan within the following chat thread: https://chat.semte.ch/channel/say-editor?msg=nARL3ndTFN8euDm7h. Currently, this functionality & styling is only implemented within a fork of the original repository and is only applicable to Kaleidos. This new styling option is currently limited to the following:
- A maximum of 5 levels (for example `2.1.2.3.7`). After this the list on the following level reverts to a default decimal list.
- No possible nesting (an extended numbered lists *within* an extended numbered lists). If this is attempted anyway the nested list reverts to a default decimal list.

### How to test/reproduce
- Open up the test-app
- Within the `Sample data:` list, click on `list` for some exemplary data (added at the far bottom of the editor)

### Challenges/uncertainties
In its current form, the new list option will suffice for usage within Kaleidos. For integration within `ember-rdfa-editor`, I'll need to pick this up again with Arne.

### Checks PR readiness
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
