### PR TITLE
Addition of functionality to extended decimal list (styling) option

### DIFF
--- a/addon/components/plugins/list/ordered.hbs
+++ b/addon/components/plugins/list/ordered.hbs
@@ -12,9 +12,14 @@
       {{#each this.styles as |style|}}
         <Menu.Item disabled={{(or (this.styleIsActive style.name) (this.styleIsRestricted style.name))}} @menuAction={{(fn this.setStyle style.name)}}>
           {{#if (this.styleIsActive style.name)}}
-            <AuIcon @icon='check' @ariaHidden={{true}} />
-          {{/if}}
+              <AuIcon @icon='check' @ariaHidden={{true}} />
+            {{/if}}
           {{style.description}}
+          {{#if style.remark}}
+            <AuPill @skin="border" @size="small" @icon="alert-triangle" class="au-u-margin-left-tiny">
+              {{style.remark}}
+            </AuPill>
+          {{/if}}
         </Menu.Item>
       {{/each}}
     </:options>

--- a/addon/components/plugins/list/ordered.hbs
+++ b/addon/components/plugins/list/ordered.hbs
@@ -10,7 +10,7 @@
   >
     <:options as |Menu|>
       {{#each this.styles as |style|}}
-        <Menu.Item disabled={{this.styleIsActive style.name}} @menuAction={{(fn this.setStyle style.name)}}>
+        <Menu.Item disabled={{(or (this.styleIsActive style.name) (this.styleIsRestricted style.name))}} @menuAction={{(fn this.setStyle style.name)}}>
           {{#if (this.styleIsActive style.name)}}
             <AuIcon @icon='check' @ariaHidden={{true}} />
           {{/if}}

--- a/addon/plugins/list/nodes/list-nodes.ts
+++ b/addon/plugins/list/nodes/list-nodes.ts
@@ -2,7 +2,11 @@ import { Node as PNode, NodeSpec } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrs } from '@lblod/ember-rdfa-editor/core/schema';
 import { optionMapOr } from '@lblod/ember-rdfa-editor/utils/_private/option';
 
-export type OrderListStyle = 'decimal' | 'upper-roman' | 'lower-alpha';
+export type OrderListStyle =
+  | 'decimal'
+  | 'decimal-extended'
+  | 'upper-roman'
+  | 'lower-alpha';
 
 type OrderedListAttrs = typeof rdfaAttrs & {
   order: number;

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -283,45 +283,6 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
 
     &[data-list-style='decimal-extended'] {
       @include decimal-extended-styling(5, 1);
-
-      ol[data-list-style='decimal-extended'] {
-        &,
-        ol {
-          display: block !important;
-          padding: 0 0 0 3rem !important;
-          counter-reset: none !important;
-
-          li {
-            display: list-item !important;
-            counter-increment: none !important;
-
-            &:before{
-              display: inline !important;
-              content: none !important;
-            }
-          }
-        }
-
-        &[data-list-style='decimal-extended'] {
-          list-style-type: decimal !important;
-        }
-
-        & > li > ol:not([data-list-style]) {
-          list-style-type: inherit !important;
-        }
-
-        &[data-list-style='decimal'] {
-          list-style-type: decimal !important;
-        }
-
-        &[data-list-style='upper-roman'] {
-          list-style-type: upper-roman !important;
-        }
-
-        &[data-list-style='lower-alpha'] {
-          list-style-type: lower-alpha !important;
-        }
-      }
     }
 
     // Stop indenting

--- a/app/styles/ember-rdfa-editor/_c-dropdown.scss
+++ b/app/styles/ember-rdfa-editor/_c-dropdown.scss
@@ -172,6 +172,11 @@ $say-smaller-font-size: 1.4rem !default;
   margin-right: $au-unit-tiny;
 }
 
+.say-dropdown__menu [role='menuitem'] .au-c-pill img,
+.say-dropdown__menu [role='menuitem'] .au-c-pill svg {
+  margin-right: 0;
+}
+
 .say-dropdown__menu [role='menuitem'] img {
   filter: invert(43%) sepia(35%) saturate(180%) hue-rotate(173deg) brightness(97%) contrast(94%);
 }


### PR DESCRIPTION
### Overview
The addition of functionality to the extended decimal list (styling) option: the adding of the new extended decimal list option is now limited to one occurence. This means some additional styling is not needed anymore 🥳 

### How to test/reproduce
- Open up the test-app
- Within the `Sample data:` list, click on `list` for some exemplary data (added at the far bottom of the editor)

### Challenges/uncertainties
In its current form, the new list option will suffice for usage within Kaleidos. For integration within `ember-rdfa-editor`, I'll need to pick this up again with Arne.

### Checks PR readiness
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
