### PR TITLE
Fix for missing dependencies error

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "ember ts:precompile",
     "postpublish": "ember ts:clean",
     "release": "release-it",
-    "prepack": "ember ts:precompile",
+    "prepare": "ember ts:precompile",
     "postpack": "ember ts:clean"
   },
   "dependencies": {


### PR DESCRIPTION
### Overview
This PR fixes the following issue: when installing this fork (as a package) within a fresh environment, the following error occurs.

```
> ember ts:precompile
 
sh: 1: ember: not found
npm WARN Local package.json exists, but node_modules missing, did you mean to install?
npm ERR! premature close
```