### PR TITLE
Add new upper-alpha list functionality & styling

### DIFF
--- a/addon/components/plugins/list/ordered.ts
+++ b/addon/components/plugins/list/ordered.ts
@@ -40,6 +40,12 @@ export default class ListOrdered extends Component<Args> {
         ),
       },
       {
+        name: 'upper-alpha',
+        description: this.intl.t(
+          'ember-rdfa-editor.ordered-list.styles.upper-alpha',
+        ),
+      },
+      {
         name: 'upper-roman',
         description: this.intl.t(
           'ember-rdfa-editor.ordered-list.styles.upper-roman',

--- a/addon/plugins/list/nodes/list-nodes.ts
+++ b/addon/plugins/list/nodes/list-nodes.ts
@@ -6,7 +6,8 @@ export type OrderListStyle =
   | 'decimal'
   | 'decimal-extended'
   | 'upper-roman'
-  | 'lower-alpha';
+  | 'lower-alpha'
+  | 'upper-alpha';
 
 type OrderedListAttrs = typeof rdfaAttrs & {
   order: number;

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -286,6 +286,10 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
       list-style-type: lower-alpha;
     }
 
+    &[data-list-style='upper-alpha'] {
+      list-style-type: upper-alpha;
+    }
+
     &[data-list-style='decimal-extended'] {
       @include decimal-extended-styling(5, 1);
     }

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -17,6 +17,7 @@ ember-rdfa-editor:
       decimal: Numbers
       decimal-extended: Numbers (extended)
       lower-alpha: Lowercase letters
+      upper-alpha: Uppercase letters
       upper-roman: Roman Numbers
   unindent-list: List level higher
   indent-list: List level lower

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -17,6 +17,7 @@ ember-rdfa-editor:
       decimal: Getallen
       decimal-extended: Getallen (uitgebreid)
       lower-alpha: Letters
+      upper-alpha: Hoofdletters
       upper-roman: Romeinse Cijfers
   unindent-list: Lijstniveau hoger
   indent-list: Lijstniveau lager


### PR DESCRIPTION
### Overview
The addition of functionality & styling regarding a new upper-alpha list type (e.g. `A. Lorem ipsum`).

### How to test/reproduce
- Open up the test-app
- With the ordered list controls, add the new upper-alpha (named `Uppercase letters` or `Hoofdletters`) list type to the document

### Checks PR readiness
- [x] Check cancel/go-back flows
- [x] npm lint