### PR TITLE
change dependency to a fixed commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@embroider/macros": "^1.13.1",
         "@glimmer/tracking": "^1.1.2",
         "@graphy/memory.dataset.fast": "4.3.3",
-        "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
+        "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles.git#133dcb12871f9174ba8fe7dfc517e52496b14bc4",
         "@lblod/marawa": "^0.8.0-beta.2",
         "codemirror": "^6.0.1",
         "common-tags": "^1.8.0",
@@ -3468,7 +3468,8 @@
     },
     "node_modules/@guardian/prosemirror-invisibles": {
       "version": "3.0.3",
-      "resolved": "git+https://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "resolved": "git+https://git@github.com/lblod/prosemirror-invisibles.git#133dcb12871f9174ba8fe7dfc517e52496b14bc4",
+      "integrity": "sha512-uIxS7OhBDxp0ZjEKuVZS3Nkq8yZGPQl3KLMempYTIrNtSO/QuVE2qemPqBmxiFOUJqNeErnBaZBM9qTCO2D81Q==",
       "license": "MIT",
       "peerDependencies": {
         "prosemirror-model": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@embroider/macros": "^1.13.1",
     "@glimmer/tracking": "^1.1.2",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
+    "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles.git#133dcb12871f9174ba8fe7dfc517e52496b14bc4",
     "@lblod/marawa": "^0.8.0-beta.2",
     "codemirror": "^6.0.1",
     "common-tags": "^1.8.0",


### PR DESCRIPTION
### Overview
Set dependency of `@lblod/prosemirror-invisibles` to a fixed commit rather than latest.
This fixes an issue where recent commits break builds.